### PR TITLE
Update call to SerialPort constructor

### DIFF
--- a/56-xbeeapi.js
+++ b/56-xbeeapi.js
@@ -156,8 +156,9 @@ module.exports = function(RED) {
 
                                 obj.serial = new serialp.SerialPort(port,{
                                     baudrate: baud,
-                                    parser: obj.xbee.rawParser()
-                                },true, function(err, results) { if (err) { obj.serial.emit('error',err); } });
+                                    parser: obj.xbee.rawParser(),
+                                    autoOpen: true
+                                }, function(err, results) { if (err) { obj.serial.emit('error',err); } });
 
                             obj.serial.on('error', function(err) {
                                 util.log("[xbee] serial port "+port+" error "+err);

--- a/56-xbeeapi.js
+++ b/56-xbeeapi.js
@@ -154,8 +154,8 @@ module.exports = function(RED) {
                                     obj._emitter.emit('data',frame);
                                 });
 
-                                obj.serial = new serialp.SerialPort(port,{
-                                    baudrate: baud,
+                                obj.serial = new serialp(port,{
+                                    baudRate: baud,
                                     parser: obj.xbee.rawParser(),
                                     autoOpen: true
                                 }, function(err, results) { if (err) { obj.serial.emit('error',err); } });


### PR DESCRIPTION
The SerialPort constructor has changed from node-serialport v4.0.0-b3 onwards.
'openImmediately' is now replaced by an 'autoOpen' flag in the options parameter.
v4.0.0+ will throw an TypeError exception if the constructor is called with the 
openImmediately flag in place of the callback